### PR TITLE
Configure GitHub Pages deployment for React demos

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,37 @@
+name: Build and deploy React apps
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Build all projects
+        run: |
+          mkdir dist
+          for dir in */; do
+            if [ -f "$dir/package.json" ] && grep -q '"build"' "$dir/package.json"; then
+              cd "$dir"
+              npm ci
+              npm run build
+              mkdir -p "../dist/$dir"
+              cp -r dist/* "../dist/$dir"
+              cd ..
+            fi
+          done
+
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: dist
+

--- a/swap_abt_grid/src/App.tsx
+++ b/swap_abt_grid/src/App.tsx
@@ -1,7 +1,4 @@
 import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
 
 function App() {
   const [a, setA] = useState("lime");

--- a/swap_abt_grid/vite.config.ts
+++ b/swap_abt_grid/vite.config.ts
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: '/swap_abt_grid/',
   plugins: [react()],
 })

--- a/swap_abt_simple/src/App.tsx
+++ b/swap_abt_simple/src/App.tsx
@@ -1,7 +1,4 @@
 import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
 
 function App() {
   const [a, setA] = useState("lime");

--- a/swap_abt_simple/vite.config.ts
+++ b/swap_abt_simple/vite.config.ts
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: '/swap_abt_simple/',
   plugins: [react()],
 })

--- a/swap_abt_table/src/App.tsx
+++ b/swap_abt_table/src/App.tsx
@@ -1,7 +1,4 @@
 import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
 
 function App() {
   const [a, setA] = useState("lime");

--- a/swap_abt_table/tsconfig.app.json
+++ b/swap_abt_table/tsconfig.app.json
@@ -1,4 +1,4 @@
-{../swap_abt_table/node_modules/.tmp/tsconfig.app.tsbuildinfo../swap_abt_table/src
+{
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2022",

--- a/swap_abt_table/vite.config.ts
+++ b/swap_abt_table/vite.config.ts
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: '/swap_abt_table/',
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- add GitHub Action to build and publish all React projects to `gh-pages`
- set Vite base paths so each project serves from its own subfolder
- clean up unused React/Vite logo imports for successful builds

## Testing
- `npm run build` in swap_abt_simple
- `npm run build` in swap_abt_table
- `npm run build` in swap_abt_grid`

------
https://chatgpt.com/codex/tasks/task_e_68b424a1649483218487292ef99eee06