### PR TITLE
Include subproject lock files in setup-node cache

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,7 @@ jobs:
         with:
           node-version: 20
           cache: npm
+          cache-dependency-path: '**/package-lock.json'
 
       - name: Build all projects
         run: |


### PR DESCRIPTION
## Summary
- expand actions/setup-node cache to include all subproject package-lock.json files

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b5ab6991ec832183256465b030596c