### PR TITLE
chore: allow gh-pages deploy to push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,8 @@
 name: Build and deploy React apps
 
+permissions:
+  contents: write
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
## Summary
- grant deploy workflow write permissions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ad7eaa04832188b941fd50129c0a